### PR TITLE
nvmeshdiag: Support missing lsb_release

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -37,12 +37,17 @@ func main() {
 		slcInstMem := strings.Split(strFree, "\n")
 		fmt.Println(formatBoldWhite("Installed Memory:"), strings.Fields(slcInstMem[1])[1])
 	}
+	fmt.Println(formatBoldWhite("\nOperating System:"))
+	var strOSinfo string
 	if checkExecutableExists("lsb_release") {
-		fmt.Println(formatBoldWhite("\nOperating System:"))
-		strOSinfo, _ := runCommand(strings.Fields("lsb_release -a"))
-		strKernel, _ := runCommand(strings.Fields("uname -r"))
-		parseOSinfo(strOSinfo, strKernel)
+		strOSinfo, _ = runCommand(strings.Fields("lsb_release -a"))
+	} else if checkExecutableExists("hostnamectl") {
+		strOSinfo, _ = runCommand(strings.Fields("hostnamectl"))
+	} else {
+		strOSinfo, _ = runCommand(strings.Fields("cat /etc/os-release"))
 	}
+	strKernel, _ := runCommand(strings.Fields("uname -r"))
+	parseOSinfo(strOSinfo, strKernel)
 	checkNvmeshStatus()
 
 	checkSystemTuning()

--- a/src/parseosinfo.go
+++ b/src/parseosinfo.go
@@ -8,13 +8,21 @@ import (
 func parseOSinfo (o string, k string) {
 
 	strKernel := k
-	slcOS := strings.Split(o,"\n")
-	for _, line := range slcOS{
-		if strings.Contains(line, "Description:"){
-			fmt.Println("\t", "Linux Distribution:", strings.TrimSpace(strings.Split(line, ":")[1]))
+	if strings.Contains(o, "CentOS") {
+		redhat_release ,_ := runCommand(strings.Fields("cat /etc/redhat-release"))
+		fmt.Println("\t", "Linux Distribution:", strings.TrimSpace(redhat_release))
+	} else {
+		slcOS := strings.Split(o,"\n")
+		for _, line := range slcOS {
+			if strings.Contains(line, "Description:") {
+				fmt.Println("\t", "Linux Distribution:", strings.TrimSpace(strings.Split(line, ":")[1]))
+			}
+			if strings.Contains(line, "PRETTY_NAME=") {
+				fmt.Println("\t", "Linux Distribution:", strings.Replace(strings.TrimSpace(strings.Split(line, "=")[1]), "\"", "", -1))	
+			}
 		}
 	}
-	if len(strKernel) > 1{
+	if len(strKernel) > 1 {
 		fmt.Print("\t", " Kernel:", strKernel)
 	}
-	}
+}


### PR DESCRIPTION
Add support for hostnamectl or cat /ets/os-release

Print /etc/redhat-release in case OS is CentOS
Print PRETTY_NAME field when using /ets/os-release